### PR TITLE
fix main entry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "radix-themes-tw",
   "version": "0.0.8",
   "description": "",
-  "main": "index.js",
+  "main": "./dist/index.js",
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch"


### PR DESCRIPTION
My code editor wouldn't rely just on exports to find the correct file and kept telling me it didn't exist.