### PR TITLE
fix(readme): correct typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ npm install radix-themes-tw --dev
 ```
 
 ## Tokens and Classes
-This preset ovverrides the default tailwind classes with the radix ones, except for the space tokens that starts with the rx suffix (for example you can use both `px-2` based on tailwind spacing and `px-rx-2` based on radix spacing).
+This preset overrides the default tailwind classes with the radix ones, except for the space tokens that starts with the rx suffix (for example you can use both `px-2` based on tailwind spacing and `px-rx-2` based on radix spacing).
 
 For the complete list of tokens check the radix documentation: https://www.radix-ui.com/themes/docs/theme/token-reference
 


### PR DESCRIPTION
The word "ovverrides" was misspelled as "overrides" in the README file.

This PR solves #8,