### PR TITLE
Expose black and white css variables

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,8 @@ export const radixThemePreset: Config = {
       ...getColors(radixGrayColors, true),
       gray: getGrayColor("gray", colorScale),
       ...getColors(radixColors),
+      whiteA: getColor("white", 12, true),
+      blackA: getColor("black", 12, true),
       overlay: "var(--color-overlay)",
       "panel-solid": "var(--color-panel-solid)",
       "panel-translucent": "var(--color-panel-translucent)",


### PR DESCRIPTION
Black and White color palettes are used in the Radix Themes stylesheet [here](https://github.com/radix-ui/themes/blob/96b50a6ed9aa200dfdd3b6cb756c0758506ba50a/packages/radix-ui-themes/src/styles/tokens/color.css#L156C1-L157C44). As a result we can access these colors via the tailwind plugin. Happy to make any changes you think are needed. 

<img width="646" alt="Screenshot 2024-01-02 at 16 30 29" src="https://github.com/viktorbonino/radix-themes-tw/assets/55989505/cb2f132a-75b1-467c-8c02-9108dab1272d">
