### PR TITLE
fix:`{color}-contrast` and `accent-surface`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ const getColor = (color: string, scale: number, alpha?: boolean) => {
   if (!alpha) {
     colors["contrast"] = `var(--${color}-contrast)`;
     colors["surface"] =
-      color === "accent" ? "var(--color-accent)" : `var(--${color}-surface)`;
+      color === "accent" ? "var(--accent-surface)" : `var(--${color}-surface)`;
   }
 
   return colors;

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ const getColor = (color: string, scale: number, alpha?: boolean) => {
     return acc;
   }, {} as Record<number | string, string>) as Record<string | number, string>;
   if (!alpha) {
-    colors[`9-contrast`] = `var(--${color}-contrast)`;
+    colors["contrast"] = `var(--${color}-contrast)`;
     colors["surface"] =
       color === "accent" ? "var(--color-accent)" : `var(--${color}-surface)`;
   }


### PR DESCRIPTION
Changed contrast naming to remove `"9"`. I think this matches better with the new naming on Radix's side.

> `--accent-9-contrast → --accent-contrast`

Updated surface naming to match Radix variables.

Old:
```js
className="bg-red-9-contrast" // --var(--red-contrast) ✅ valid but needs `"9"`
className="bg-accent-surface" // --var(--color-accent) (DOESN'T EXIST) ❌
```

New:
```js
className="bg-red-contrast" // --var(--red-contrast) ✅
className="bg-accent-surface" // --var(--accent-surface) ✅
```