### PR TITLE
fix: correct font weight values to match Radix Themes documentation

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -130,9 +130,8 @@ ${
   /* font weight */
   --font-weight-light: 300;
   --font-weight-regular: 400;
-  --font-weight-normal: 400;
-  --font-weight-normal: 500;
-  --font-weight-medium: 700;
+  --font-weight-medium: 500;
+  --font-weight-bold: 700;
 
   /* border radius */
   --radius-1: var(--radius-1);

--- a/src/index.css
+++ b/src/index.css
@@ -111,9 +111,8 @@
   /* font weight */
   --font-weight-light: 300;
   --font-weight-regular: 400;
-  --font-weight-normal: 400;
-  --font-weight-normal: 500;
-  --font-weight-medium: 700;
+  --font-weight-medium: 500;
+  --font-weight-bold: 700;
 
   /* border radius */
   --radius-1: var(--radius-1);

--- a/src/theme.css
+++ b/src/theme.css
@@ -106,9 +106,8 @@
   /* font weight */
   --font-weight-light: 300;
   --font-weight-regular: 400;
-  --font-weight-normal: 400;
-  --font-weight-normal: 500;
-  --font-weight-medium: 700;
+  --font-weight-medium: 500;
+  --font-weight-bold: 700;
 
   /* border radius */
   --radius-1: var(--radius-1);


### PR DESCRIPTION
Refer to Radix Themes docs at https://www.radix-ui.com/themes/docs/theme/typography#font-weight 

- Remove duplicate `--font-weight-normal` declarations
- Set `--font-weight-medium` to 500 (was incorrectly 700)
- Add `--font-weight-bold` with value 700